### PR TITLE
editted tooltip for chart

### DIFF
--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -30,6 +30,13 @@ const BarChart = (props) => {
             },
             title: {
                 display: false
+            },
+            tooltip: {
+                callbacks: {
+                    label: function(context) {
+                        return context.parsed.y;
+                    }
+                }
             }
         },
         scales: {


### PR DESCRIPTION
tooltip now just shows the attribute name and value, not pokemon name